### PR TITLE
fix release date of "プリンセスコネクト！Re:Dive"

### DIFF
--- a/src/data.yaml
+++ b/src/data.yaml
@@ -1,5 +1,5 @@
-- title: プリンセスコネクト
-  published: "2015-02-15"
+- title: プリンセスコネクト！Re:Dive
+  published: "2018-02-15"
   url: https://priconne-redive.jp/
 - title: "Fate/Grand Order"
   published: "2015-07-30"


### PR DESCRIPTION
現在サービスが続いているのは続編のほうなので、名前とリリース日を続編に合わせました。
ref: https://priconne-redive.jp/news/information/804/