### PR TITLE
feat: ダブルタップ防止のCSSを追加 closed #27

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -2,6 +2,7 @@ html {
   background-color: #151618;
   font-family: "Helvetica Neue", Arial, "Hiragino Kaku Gothic ProN",
     "Hiragino Sans", "BIZ UDPGothic", Meiryo, sans-serif;
+  touch-action: manipulation;
 }
 
 body {


### PR DESCRIPTION
本番環境を確認したところ、Androidではすでにダブルタップズームが抑制されていたので、  
iPhoneを持っていない私の環境では #27 の挙動が再現できませんでした。

モバイルsafariのダブルタップズームはおそらくこのCSSで抑制できると思います。（だめだったらごめんなさい）

https://developer.mozilla.org/ja/docs/Web/CSS/touch-action